### PR TITLE
Update docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,10 @@ on:
           type: boolean
           default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     docs-prebuild:
         runs-on: ubuntu-latest


### PR DESCRIPTION
为文档构建增加并发限制，防止多个构建同时发布到gh-pages分支导致失败。